### PR TITLE
Override getComponentName instead of component-list for Clayhandlebars

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -18,10 +18,9 @@ let amphoraFs = require('amphora-fs'),
  */
 function init() {
   hbs.registerPartial('noop-component', '');
-  // Override the `component-list` helper provided by clayhandlebars so that it will log on unfound
+  // Override the `getComponentName` helper provided by clayhandlebars so that it will log on unfound
   // partials instead of breaking the render.
-  hbs.registerPartial('component-list', '{{#each this~}}{{~> (getComponentNameOrLog _ref) ~}}{{~/each}}');
-  hbs.registerHelper('getComponentNameOrLog', safeGetComponentName(hbs, log));
+  hbs.registerHelper('getComponentName', safeGetComponentName(hbs, log));
 
   // Register partials
   registerPartials();


### PR DESCRIPTION
Overriding `component-list` is not generic enough because in a few templates there are direct calls to `getComponentName`, overriding that helper will cover a lot more ground.